### PR TITLE
Add `SqlString.fn` Function Call Proxy

### DIFF
--- a/lib/SqlString.js
+++ b/lib/SqlString.js
@@ -45,8 +45,8 @@ SqlString.escape = function escape(val, stringifyObjects, timeZone) {
         return SqlString.arrayToList(val, timeZone);
       } else if (Buffer.isBuffer(val)) {
         return SqlString.bufferToString(val);
-      } else if (typeof val.toSQL === 'function') {
-        return val.toSQL('mysql');
+      } else if (val instanceof SqlFunction) {
+        return val.toSQL();
       } else if (stringifyObjects) {
         val = val.toString();
       } else {
@@ -170,6 +170,26 @@ SqlString.objectToValues = function objectToValues(object, timeZone) {
 
   return sql;
 };
+
+if (typeof Proxy === 'function') {
+  SqlString.fn = new Proxy({}, {
+    get(target, name) {
+      if (name in target) {
+        return target[name];
+      }
+
+      return (...args) => new SqlFunction(name, args);
+    }
+  });
+}
+
+function SqlFunction(name, args) {
+  const escapedArgs = args.map(SqlString.escape).join(', ');
+
+  this.toSQL() {
+    return `${name.toUpperCase()}(${escapedArgs})`;
+  };
+}
 
 function escapeString(val) {
   var chunkIndex = charsRegex.lastIndex = 0;

--- a/test/unit/test-SqlString.js
+++ b/test/unit/test-SqlString.js
@@ -216,17 +216,6 @@ test('SqlString.escape', {
     assert.strictEqual(string, expected);
   },
 
-  'objects with toSQL() methods are passed "mysql" as first parameter': function() {
-    function WithDialect() {
-      this.toSQL = function(dialect) {
-        assert.strictEqual(dialect, 'mysql');
-      };
-    }
-
-    var input    = new WithDialect();
-    var string   = SqlString.escape(input);
-  },
-
   'NaN -> NaN': function() {
     assert.equal(SqlString.escape(NaN), 'NaN');
   },


### PR DESCRIPTION
Adds the ability to raw "escape" by calling any `SqlString.fn.*` property as a function.

It takes the Proxy example from #9 and merges it in directly into the library.

It only works on Node.js v6+ (according to [node.green](http://node.green)), but there is a check so that users of lower versions can use the library (without `SqlString.fn.*` support), which is a con #9 didn't have..

Examples:
```js
const a = SqlString.fn.POINT(123, 456);
const b = SqlString.fn.CURRENT_TIMESTAMP();
const c = SqlString.fn.CONCAT(SqlString.fn.UPPER('abc'), SqlString.fn.LOWER('ABC'));

SqlString.escape(a); // -> POINT(123, 456)
SqlString.escape(b); // -> CURRENT_TIMESTAMP()
SqlString.escape(c); // -> CONCAT(UPPER("abc"), LOWER("ABC"))
```

Should be a lot more secure than #9, since the escape function checks if the value from the `SqlString.fn.*` call is in an instance of an internal function class (`SqlFunction`) that doesn't get exported. It also escapes all arguments.

Playing (security) devils advocate:
- If someone has external influence on `SqlString.fn` or `SqlString.escape`, you're screwed.
- If someone has external influence on `Array.prototype.map`, you're screwed.
- If someone has external influence on the global Proxy class, you're screwed.
- If someone has external influence on your app, you're screwed.